### PR TITLE
GRIDEDIT-2301: Removed latitude parameter from `Mesh2dMakeGlobal` API

### DIFF
--- a/src/MeshKernelNET/Api/IMeshKernelApi.cs
+++ b/src/MeshKernelNET/Api/IMeshKernelApi.cs
@@ -1376,13 +1376,12 @@ namespace MeshKernelNET.Api
                                            ref int[] faceEdgeIndex);
 
         /// <summary>
-        /// Compute the global mesh with a given number of points along the longitude and latitude directions.
+        /// Compute the global mesh with a given number of points along the longitude direction.
         /// </summary>
         /// <param name="meshKernelId">Id of the mesh state</param>
         /// <param name="numLongitudeNodes">The number of points along the longitude</param>
-        /// <param name="numLatitudeNodes">The number of points along the latitude (half hemisphere)</param>
         /// <returns>Error code</returns>
-        int Mesh2dMakeGlobal(int meshKernelId, int numLongitudeNodes, int numLatitudeNodes);
+        int Mesh2dMakeGlobal(int meshKernelId, int numLongitudeNodes);
 
         /// <summary>
         /// Make a triangular grid in a polygon

--- a/src/MeshKernelNET/Api/MeshKernelApi.cs
+++ b/src/MeshKernelNET/Api/MeshKernelApi.cs
@@ -1390,9 +1390,9 @@ namespace MeshKernelNET.Api
             return successful;
         }
 
-        public int Mesh2dMakeGlobal(int meshKernelId, int numLongitudeNodes, int numLatitudeNodes)
+        public int Mesh2dMakeGlobal(int meshKernelId, int numLongitudeNodes)
         {
-            return MeshKernelDll.Mesh2dMakeGlobal(meshKernelId, numLongitudeNodes, numLatitudeNodes);
+            return MeshKernelDll.Mesh2dMakeGlobal(meshKernelId, numLongitudeNodes);
         }
 
         public int Mesh2dMakeTriangularMeshFromPolygon(int meshKernelId, DisposableGeometryList disposableGeometryList, double scaleFactor)

--- a/src/MeshKernelNET/Native/MeshKernelDll.cs
+++ b/src/MeshKernelNET/Native/MeshKernelDll.cs
@@ -1723,14 +1723,13 @@ namespace MeshKernelNET.Native
                                                                   [In][Out] IntPtr faceEdgeIndex);
 
         /// <summary>
-        /// Compute the global mesh with a given number of points along the longitude and latitude directions.
+        /// Compute the global mesh with a given number of points along the longitude direction.
         /// </summary>
         /// <param name="meshKernelId">Id of the mesh state</param>
         /// <param name="numLongitudeNodes">The number of points along the longitude</param>
-        /// <param name="numLatitudeNodes">The number of points along the latitude (half hemisphere)</param>
         /// <returns>Error code</returns>
         [DllImport(MeshKernelDllName, EntryPoint = "mkernel_mesh2d_make_global", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Mesh2dMakeGlobal(int meshKernelId, int numLongitudeNodes, int numLatitudeNodes);
+        internal static extern int Mesh2dMakeGlobal(int meshKernelId, int numLongitudeNodes);
 
         /// <summary>
         /// Make a triangular grid in a polygon

--- a/test/MeshKernelNET.Tests/Api/MeshKernelApiTest.cs
+++ b/test/MeshKernelNET.Tests/Api/MeshKernelApiTest.cs
@@ -3424,7 +3424,7 @@ namespace MeshKernelNET.Tests.Api
                 {
                     int projectionType = 1;
                     id = api.AllocateState(projectionType);
-                    Assert.That(api.Mesh2dMakeGlobal(id, 19, 25), Is.EqualTo(0));
+                    Assert.That(api.Mesh2dMakeGlobal(id, 19), Is.EqualTo(0));
 
                     Assert.That(api.Mesh2dGetData(id, out mesh2d), Is.EqualTo(0));
                     Assert.That(mesh2d.NumEdges, Is.EqualTo(1225));


### PR DESCRIPTION
Update to MeshKernel API change: https://github.com/Deltares/MeshKernel/pull/544